### PR TITLE
Print errno when watchdog hypercall fails

### DIFF
--- a/daemon/watchdog.c
+++ b/daemon/watchdog.c
@@ -320,15 +320,13 @@ do_hypercall(privcmd_hypercall_t *hypercall, void *arg, size_t argsize, int *ioc
     else
     {
         ret = ioctl(hypercall_fd, IOCTL_PRIVCMD_HYPERCALL, hypercall);
-    }
-    if (ret < 0)  
-    {
-
-        if (currentstatus == MTC_SUCCESS)
+        if (ret < 0 && currentstatus == MTC_SUCCESS)
         {
-            log_internal(MTC_LOG_ERR, "WD: hypercall failed (sys %d).\n", ret);
+            log_internal(MTC_LOG_ERR, "WD: hypercall failed (sys %d).\n", errno);
         }
-
+    }
+    if (ret < 0)
+    {
         unlock_pages(hypercall, sizeof(privcmd_hypercall_t));
         unlock_pages(arg, argsize);
         return MTC_ERROR_WD_INSTANCE_UNAVAILABLE ;

--- a/daemon/watchdog.c
+++ b/daemon/watchdog.c
@@ -325,14 +325,14 @@ do_hypercall(privcmd_hypercall_t *hypercall, void *arg, size_t argsize, int *ioc
             log_internal(MTC_LOG_ERR, "WD: hypercall failed (sys %d).\n", errno);
         }
     }
-    if (ret < 0)
-    {
-        unlock_pages(hypercall, sizeof(privcmd_hypercall_t));
-        unlock_pages(arg, argsize);
-        return MTC_ERROR_WD_INSTANCE_UNAVAILABLE ;
-    }
+
     unlock_pages(hypercall, sizeof(privcmd_hypercall_t));
     unlock_pages(arg, argsize);
+
+    if (ret < 0)
+    {
+        return MTC_ERROR_WD_INSTANCE_UNAVAILABLE ;
+    }
 
     *ioctl_ret = ret;
     return MTC_SUCCESS;


### PR DESCRIPTION
Previously the return of ioctl was being printed on error, printing
always -1, regardless of what caused the failure.

Now the message of hypercall failed is not printed when the watchdog was already unavailable.

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>