### PR TITLE
Watchdog reset

### DIFF
--- a/commands/cleanupwatchdog.c
+++ b/commands/cleanupwatchdog.c
@@ -371,7 +371,7 @@ main(
 
     if ((fp = fopen(WATCHDOG_INSTANCE_ID_FILE, "r")) == NULL)
     {
-        return MTC_SUCCESS;
+        return MTC_EXIT_SUCCESS;
     }
     while (fgets(buf, sizeof(buf), fp) != NULL)
     {
@@ -393,6 +393,15 @@ main(
             continue;
         }
         status = do_watchdog_hypercall(&(id[idindex]), 0);
+
+        if (status == MTC_ERROR_WD_INSUFFICIENT_RESOURCE)
+        {
+            return MTC_EXIT_TRANSIENT_SYSTEM_ERROR;
+        }
+        if (status != MTC_SUCCESS)
+        {
+            return MTC_EXIT_INTERNAL_BUG;
+        }
     }
     return MTC_EXIT_SUCCESS;
 }

--- a/commands/cleanupwatchdog.c
+++ b/commands/cleanupwatchdog.c
@@ -332,7 +332,8 @@ do_watchdog_disable(uint32_t *id)
 //
 //  FORMAL PARAMETERS:
 //
-//          
+//      --force: disable the first 2 watchdog slots for xhad
+//
 //  RETURN VALUE:
 //
 //      MTC_EXIT_SUCCESS - success the call
@@ -365,6 +366,23 @@ main(
 
     if ((fp = fopen(WATCHDOG_INSTANCE_ID_FILE, "r")) == NULL)
     {
+        if (argc == 2 && !strcmp(argv[1], "--force"))
+        {
+            // xhad uses 2 slots; 0 is for requesting a new slot
+            for (idindex = 1; idindex < 3; idindex++)
+            {
+                status = do_watchdog_disable(&idindex);
+
+                if (status == MTC_ERROR_WD_INSUFFICIENT_RESOURCE)
+                {
+                    return MTC_EXIT_TRANSIENT_SYSTEM_ERROR;
+                }
+                if (status == MTC_ERROR_UNDEFINED)
+                {
+                    return MTC_EXIT_INTERNAL_BUG;
+                }
+            }
+        }
         return MTC_EXIT_SUCCESS;
     }
     while (fgets(buf, sizeof(buf), fp) != NULL)

--- a/scripts/ha_start_daemon
+++ b/scripts/ha_start_daemon
@@ -46,6 +46,9 @@ if [ $retval -ne $MTC_EXIT_DAEMON_IS_NOT_PRESENT ]; then
     exit $MTC_EXIT_DAEMON_IS_PRESENT
 fi
 
+#   flush watchdog slots
+cleanupwatchdog --force
+
 #   start xha daemon
 
 portrelease xhad 2&>1 > /dev/null || true


### PR DESCRIPTION
There are two changes:
- Introduce a command-line option to allow resetting all watchdog slots when there is no HA watchdog file.
- Reset the watchdog slots in the startup HA script right before the HA daemon is started.

This is done to minimize failures in the daemon in case the slots are used, the HA watchdog file has been deleted; and the HA daemon is not running.

This changes assume the HA daemon is the only that is allowed to manage this slots, which is reasonable in the case of XS (2 slots exists; one is used for state-file tracking, the other for heartbeat tracking, both by the HA daemon)

Depends on https://github.com/xenserver/xha/pull/7