### PR TITLE
    CP-41049: Safely remove /proc/xen from dom0

### DIFF
--- a/commands/cleanupwatchdog.c
+++ b/commands/cleanupwatchdog.c
@@ -98,7 +98,7 @@
 ////
 
 
-#define PRIVCMD_PATH "/proc/xen/privcmd"
+#define PRIVCMD_PATH "/dev/xen/privcmd"
 #define MAX_WATCHDOG_INSTANCE 8
 
 

--- a/daemon/watchdog.c
+++ b/daemon/watchdog.c
@@ -73,7 +73,7 @@
 //
 ////
 
-#define PRIVCMD_PATH "/proc/xen/privcmd"
+#define PRIVCMD_PATH "/dev/xen/privcmd"
 #define MAX_WATCHDOG_INSTANCE 8
 
 typedef struct watchdog_instance 


### PR DESCRIPTION
    /proc/xen/privcmd is now /dev/xen/privcmd

    Signed-off-by: Per Bilse <per.bilse@citrix.com>