### PR TITLE
lib: ensure the correct maximum amount of hosts

### DIFF
--- a/lib/config.c
+++ b/lib/config.c
@@ -384,7 +384,7 @@ walk_host_config(
     // Walk XML
     //
 
-    if (c->common.hostnum > MAX_HOST_NUM) 
+    if (c->common.hostnum >= MAX_HOST_NUM) 
     {
         log_internal(MTC_LOG_ERR,
                     "%s: hostnum(%d) exceeds MAX_HOST_NUM(%d)\n",


### PR DESCRIPTION
When reading the XML configuration ensure that not too many hosts are defined. This issue is hard to hit as it only happens in unsupported configurations