### PR TITLE
CA-403139/CA-403683: Set scheduler and improve log printing

### DIFF
--- a/daemon/heartbeat.c
+++ b/daemon/heartbeat.c
@@ -1030,7 +1030,7 @@ send_hb()
         com_reader_unlock(sm_object);
     }
 
-    log_maskable_debug_message(DUMPPACKET, "HB: sending a heartbeat packet.\n");
+    log_maskable_debug_message(TRACE, "HB: sending a heartbeat packet.\n");
     maskable_dump(DUMPPACKET, (void *) &pkt, sizeof(pkt));
 
 
@@ -1215,7 +1215,7 @@ receive_hb()
             }
         }
 
-        log_maskable_debug_message(DUMPPACKET,
+        log_maskable_debug_message(TRACE,
                      "HB: heartbeat received from host (%d).\n", fm_index);
         maskable_dump(DUMPPACKET, (PMTC_S8) &pkt, recvd);
 

--- a/daemon/log.c
+++ b/daemon/log.c
@@ -292,8 +292,7 @@ void log_message(MTC_S32 priority, PMTC_S8 fmt, ...)
 
 
     }
-    
-    if (priority & MTC_LOG_SYSLOG)
+    if ((logmask & MTC_LOG_MASK_SYSLOG) || (priority & MTC_LOG_SYSLOG))
     {
         va_start(ap, fmt);
         vsyslog(LOG_PRI(priority), fmt, ap);

--- a/include/log.h
+++ b/include/log.h
@@ -64,10 +64,11 @@ extern MTC_S32  logmask;
 #define MTC_LOG_MASK_LM_TRACE   (1<<21)
 #define MTC_LOG_MASK_SCRIPT     (1<<22)
 #define MTC_LOG_MASK_SC_WARNING (1<<23)
+#define MTC_LOG_MASK_SYSLOG     (1<<24)
 
 #define LOG_MASK_BASE           18
 #define LOG_MASK_BITS           (32 - LOG_MASK_BASE)
-#define LOG_MASK_NAMES {"DUMPPACKET", "TRACE", "FH_TRACE", "LM_TRACE", "SCRIPT", "SC_WARNING", NULL}
+#define LOG_MASK_NAMES {"DUMPPACKET", "TRACE", "FH_TRACE", "LM_TRACE", "SCRIPT", "SC_WARNING", "SYSLOG", NULL}
 
 #ifdef NDEBUG
 #define DEFAULT_LOG_MASK    (0)


### PR DESCRIPTION
The current xha only moves the main thread to the root cgroup and sets its RR
scheduler. It doesn't do these for all its sub-threads. This leads these sub-threads
can't be scheduled enough resources. So this commit fixes this issue by the following
two changes:
1. All threads will inherit the process's scheduler policy and priority.
2. Move the scheduler setting code to the position before all sub-thread creations
  so they can inherit the process's scheduler configuration.

Besides these, this PR contains below log improvements:
1. Support to configure whether to print all logs (except DUMPPACKET level log)
   to rsyslog (currently, INFO, WARN, and DEBUG can't be printed to rsyslog).
2. Increase heartbeat receiving and sending log level from DUMPPACKET to TRACE
   so that heartbeat log can be printed to syslog.

