### PR TITLE
CA-406953: avoid pointer truncation and uninitialised value usage

### DIFF
--- a/commands/cleanupwatchdog.c
+++ b/commands/cleanupwatchdog.c
@@ -237,7 +237,7 @@ do_watchdog_disable(uint32_t *id)
 
     hypercall.op = __HYPERVISOR_sched_op;
     hypercall.arg[0] = SCHEDOP_watchdog;
-    hypercall.arg[1] = (__u64) (unsigned int) &arg;  // pointer to u64
+    hypercall.arg[1] = (uintptr_t) &arg;  // pointer to u64
     arg.id = *id;
     arg.timeout = 0;
 

--- a/daemon/bond_mon.c
+++ b/daemon/bond_mon.c
@@ -358,6 +358,7 @@ bm_initialize(
         com_close(bm_object);
         bm_object = HA_COMMON_OBJECT_INVALID_HANDLE_VALUE;
 #endif
+        ret = MTC_ERROR_INVALID_PARAMETER;
 
         break;
     }

--- a/daemon/watchdog.c
+++ b/daemon/watchdog.c
@@ -407,7 +407,7 @@ do_watchdog_hypercall(uint32_t *id, uint32_t timeout, MTC_STATUS currentstatus)
 
     hypercall.op = __HYPERVISOR_sched_op;
     hypercall.arg[0] = SCHEDOP_watchdog;
-    hypercall.arg[1] = (__u64) (unsigned int) &arg;  // pointer to u64
+    hypercall.arg[1] = (uintptr_t) &arg;  // pointer to u64
     arg.id = *id;
     arg.timeout = timeout;
     
@@ -501,7 +501,7 @@ do_domain_shutdown_self(MTC_STATUS currentstatus)
 
     hypercall.op = __HYPERVISOR_sched_op;
     hypercall.arg[0] = SCHEDOP_remote_shutdown;
-    hypercall.arg[1] = (__u64) (unsigned int) &arg;  // pointer to u64
+    hypercall.arg[1] = (uintptr_t) &arg;  // pointer to u64
     arg.domain_id = 0;
     arg.reason = 1; // reboot
     

--- a/daemon/watchdog.c
+++ b/daemon/watchdog.c
@@ -994,7 +994,7 @@ watchdog_selffence(void)
     log_message(MTC_LOG_INFO, "watchdog_selffence.\n");
     
     // Attempt to shutdown domain 0 immediately
-    do_domain_shutdown_self(ret);
+    do_domain_shutdown_self(MTC_ERROR_HB_FENCEREQUESTED);
     // We shouldn't get here but if we do then invoke the watchdog:
 
     if (instance_num == 0)

--- a/default-debug.mk
+++ b/default-debug.mk
@@ -4,7 +4,7 @@
 
 CC=gcc
 SOURCEDIR=..
-CFLAGS=-g -Wall -Wno-multichar
+CFLAGS=-g -Wall -Wno-multichar -Werror=pointer-to-int-cast
 
 
 OBJDIR=$(SOURCEDIR)/debug

--- a/default-release.mk
+++ b/default-release.mk
@@ -4,7 +4,7 @@
 
 CC=gcc
 SOURCEDIR=..
-CFLAGS=-g -Wall -Wno-multichar
+CFLAGS=-g -Wall -Wno-multichar -Werror=pointer-to-int-cast
 
 CFLAGS+=-DNDEBUG 
 OBJDIR=$(SOURCEDIR)/release

--- a/include/mtctypes.h
+++ b/include/mtctypes.h
@@ -54,7 +54,7 @@
 //
 
 #include <sys/time.h>
-
+#include <stddef.h>
 
 //
 //
@@ -442,8 +442,7 @@ MTC_ASSERT_SIZE(sizeof (void *) == MTC_POINTER_SIZE);
 
 #define _rounddiv(num, div)     (((num) + (div) - 1) / (div))
 #define _roundup(num, div)      (_rounddiv(num, div) * (div))
-#define _struct_offset(structname, element) \
-                                ((unsigned int)&(((structname *)0)->element))
+#define _struct_offset(structname, element) offsetof(structname, element)
 
 #ifndef _min
 #define _min(X, Y)      ((X < Y)? (X): (Y))

--- a/lib/statefileio.c
+++ b/lib/statefileio.c
@@ -39,6 +39,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <pthread.h>
+#include <stdint.h>
 #include <signal.h>
 #include <string.h>
 #include <unistd.h>
@@ -354,7 +355,7 @@ sf_checksum(
 {
     MTC_U32 sum = 0;
 
-    assert((((MTC_U32)p) & 3) == 0 && (((MTC_U32)end) & 3) == 0);
+    assert((((uintptr_t)p) & 3) == 0 && (((uintptr_t)end) & 3) == 0);
 
     while (p < end)
     {


### PR DESCRIPTION
Looks like `xha` never got ported to 64-bit and still has a lot of 32-bit specific code.

When casting a pointer to integer we should use `uintptr_t`, which matches the size of a pointer (32-bit on 32-bit platforms, 64-bit on 64-bit platforms).

Otherwise we may lose the upper 32-bit of a pointer in hypercall arguments, which will likely cause the hypercall to fail.

Found by compiler warnings (GCC/Clang).

There are more compiler warnings that we should fix, but they are not so critical as this one.