### PR TITLE
Add a CI to `xha` repo

### DIFF
--- a/.github/workflows/codechecker.yaml
+++ b/.github/workflows/codechecker.yaml
@@ -1,0 +1,53 @@
+name: "CodeChecker analysis"
+
+on:
+  push:
+  pull_request:
+    
+concurrency: # On new push, cancel old workflows from the same PR, branch or tag:
+  group: ${{ github.workflow }}-${{github.event_name}}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: "Check out repository"
+        uses: actions/checkout@v4
+
+      - name: "Install dependencies"
+        run: sudo apt-get install -y libxml2-dev libxen-dev bear
+
+      # ldlogger.so in codechecker seems to have been built for 32-bit,
+      # use bear instead
+      - name: "Create compilation commands database"
+        run: bear -- make debug
+
+      # SARIF output conversion support is only in master
+      # hence install-custom is set to true
+      # Uses Cross-Translation-Unit analysis, which is best supported in CodeChecker, not scan-build
+      - uses: whisperity/codechecker-analysis-action@v1
+        id: codechecker
+        with:
+          install-custom: true
+          logfile: ${{ github.workspace }}/compile_commands.json
+          ctu: true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "CodeChecker Bug Reports"
+          path: ${{ steps.codechecker.outputs.result-html-dir }}
+
+      # TODO: how to get the path here?
+      # for some reason this exits with 2 probably to mean errors were found, but we need a successful exit
+      - name: "Convert to SARIF"
+        run: /home/runner/work/xha/xha/CodeChecker/analyzer/build/CodeChecker/bin/CodeChecker parse -e sarif ${{ steps.codechecker.outputs.analyze-output }} -o codechecker.sarif
+        continue-on-error: true
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+            sarif_file: codechecker.sarif
+            category: codechecker

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,41 @@
+name: Build and test
+
+on:
+  push:
+  pull_request:
+  merge_group:
+
+concurrency: # On new push, cancel old workflows from the same PR, branch or tag:
+  group: ${{ github.workflow }}-${{github.event_name}}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies (apt)
+        run: sudo apt-get install -y libxml2-dev libxen-dev
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: make
+
+  build-container:
+    strategy:
+      matrix:
+        image:
+          - fedora:latest
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.image }}
+    steps:
+      - name: Install dependencies (dnf)
+        run: dnf install -y libxml2-devel xen-devel make gcc
+      
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: make

--- a/commands/Makefile
+++ b/commands/Makefile
@@ -22,23 +22,23 @@ OBJS    += $(OBJDIR)/weightctl.o
 all: $(OBJS) $(TARGET)
 
 $(OBJDIR)/calldaemon: $(OBJS) $(HALIBS)
-	$(CC) $(OBJDIR)/calldaemon.o $(LIBS) $(HALIBS) -o $@
+	$(CC) $(OBJDIR)/calldaemon.o $(HALIBS) $(LIBS) -o $@
 	@chmod 0755 $@
 
 $(OBJDIR)/writestatefile: $(OBJS) $(HALIBS)
-	$(CC) $(OBJDIR)/writestatefile.o $(OBJDIR)/stubs.o $(LIBS) $(HALIBS) -o $@
+	$(CC) $(OBJDIR)/writestatefile.o $(OBJDIR)/stubs.o $(HALIBS) $(LIBS) -o $@
 	@chmod 0755 $@
 
 $(OBJDIR)/dumpstatefile:$(OBJS) $(HALIBS)
-	$(CC) $(OBJDIR)/dumpstatefile.o $(OBJDIR)/stubs.o $(LIBS) $(HALIBS) -o $@
+	$(CC) $(OBJDIR)/dumpstatefile.o $(OBJDIR)/stubs.o $(HALIBS) $(LIBS) -o $@
 	@chmod 0755 $@
 
 $(OBJDIR)/cleanupwatchdog:$(OBJS) $(HALIBS)
-	$(CC) $(OBJDIR)/cleanupwatchdog.o $(LIBS) $(HALIBS) -o $@
+	$(CC) $(OBJDIR)/cleanupwatchdog.o $(HALIBS) $(LIBS) -o $@
 	@chmod 0755 $@
 
 $(OBJDIR)/weightctl:$(OBJS) $(HALIBS)
-	$(CC) $(OBJDIR)/weightctl.o $(LIBS) $(HALIBS) -o $@
+	$(CC) $(OBJDIR)/weightctl.o $(HALIBS) $(LIBS) -o $@
 	@chmod 0755 $@
 
 install: $(TARGET)

--- a/daemon/sm.c
+++ b/daemon/sm.c
@@ -817,7 +817,7 @@ rendezvous(
     MTC_BOOLEAN on_statefile)
 {
 #if RENDEZVOUS_FAULT_HANDLING
-    void rendezvous_wait(p1, p2)
+    void rendezvous_wait(SM_PHASE p1, SM_PHASE p2)
     {
         PCOM_DATA_SM    psm;
         PCOM_DATA_HB    phb;

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -18,7 +18,7 @@ $(TARGET): $(TARGET_GENERR)
 	@chmod 0755 $@
 
 $(TARGET_GENERR): $(OBJS_GENERR) $(HALIBS)
-	$(CC) $(OBJS_GENERR) $(LIBS) $(HALIBS) -o $@
+	$(CC) $(OBJS_GENERR) $(HALIBS) $(LIBS) -o $@
 	@chmod 0755 $@
 
 $(HALIBS):


### PR DESCRIPTION
The CI builds the project using `make`.

It also runs the Clang static analyzer (via CodeChecker).

I tried to also add `gcc -fanalyzer` support, but the tooling around processing the SARIF file it produces is too buggy at the moment.