### PR TITLE
CA-406953: fix more undefined behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ include/mtcerrno.h
 scripts/generr
 scripts/generr.o
 scripts/ha_errnorc
+compile_commands.json
+.cache/

--- a/commands/stubs.c
+++ b/commands/stubs.c
@@ -41,6 +41,7 @@
 
 #include "mtctypes.h"
 #include "mtcerrno.h"
+#include "log.h"
 
 void
 log_message(
@@ -51,7 +52,7 @@ log_message(
     va_list     ap;
 
     va_start(ap, fmt);
-    fprintf(stderr, fmt, ap);
+    (void)vfprintf(stderr, fmt, ap);
     va_end(ap);
 
     fflush(stderr);

--- a/daemon/com.c
+++ b/daemon/com.c
@@ -37,6 +37,7 @@
 #include <assert.h>
 #include <unistd.h>
 #include <signal.h>
+#include <inttypes.h>
 
 #include "mtctypes.h"
 #include "mtcerrno.h"
@@ -269,7 +270,7 @@ MTC_STATIC HA_COMMON_OBJECT_HANDLE_INTERNAL
     new_handle = malloc(sizeof(HA_COMMON_OBJECT_HANDLE_INTERNAL));
     if (new_handle == NULL) 
     {
-        log_internal(MTC_LOG_ERR, "COM: cannot allocate for object_handle (size=%d).\n", sizeof(HA_COMMON_OBJECT_HANDLE_INTERNAL));
+        log_internal(MTC_LOG_ERR, "COM: cannot allocate for object_handle (size=%zu).\n", sizeof(HA_COMMON_OBJECT_HANDLE_INTERNAL));
         return NULL;
     }
     new_handle->object = object;
@@ -307,7 +308,7 @@ new_object(
     new = malloc(sizeof(HA_COMMON_OBJECT));
     if (new == NULL) 
     {
-        log_internal(MTC_LOG_ERR, "COM: cannot allocate for object (size=%d).\n", sizeof(HA_COMMON_OBJECT));
+        log_internal(MTC_LOG_ERR, "COM: cannot allocate for object (size=%zu).\n", sizeof(HA_COMMON_OBJECT));
         return NULL;
     }
     new->next = NULL;
@@ -452,7 +453,7 @@ MTC_STATIC HA_COMMON_OBJECT_CALLBACK_LIST_ITEM
     new = malloc(sizeof(HA_COMMON_OBJECT_CALLBACK_LIST_ITEM));
     if (new == NULL) 
     {
-        log_internal(MTC_LOG_ERR, "COM: cannot allocate for callback (size=%d).\n", sizeof(HA_COMMON_OBJECT_CALLBACK_LIST_ITEM));
+        log_internal(MTC_LOG_ERR, "COM: cannot allocate for callback (size=%zu).\n", sizeof(HA_COMMON_OBJECT_CALLBACK_LIST_ITEM));
         return NULL;
     }
     new->next = NULL;
@@ -573,7 +574,7 @@ set_thread_id_record(
                 return;
             }
         }
-        log_message(MTC_LOG_WARNING, "COM: thread_id %d not found in thraed_id_record_table.\n", self);
+        log_message(MTC_LOG_WARNING, "COM: thread_id %lu not found in thread_id_record_table.\n", self);
         break;
     }
     assert(FALSE);
@@ -619,7 +620,7 @@ com_log_all_objects(
             {
                 if (object->thread_id_record_table[tid_index].lock_state != LOCK_STATE_NONE)
                 {
-                    log_message(MTC_LOG_DEBUG, "COM:     lock_state=%d thread_id=%x changed_time=%d(ms) .\n",
+                    log_message(MTC_LOG_DEBUG, "COM:     lock_state=%d thread_id=0x%lx changed_time=%"PRId64"(ms) .\n",
                                 object->thread_id_record_table[tid_index].lock_state,
                                 object->thread_id_record_table[tid_index].thread_id,
                                 now - object->thread_id_record_table[tid_index].changed_time

--- a/daemon/heartbeat.c
+++ b/daemon/heartbeat.c
@@ -45,6 +45,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 
 //
@@ -1454,7 +1455,7 @@ hb_check_fist(
     if (target_delay != 0)
     {
         log_message(MTC_LOG_DEBUG,
-                    "HB(FIST): heartbeat delay is %d ms\n", target_delay);
+                    "HB(FIST): heartbeat delay is %"PRId64" ms\n", target_delay);
 
         ts = ts_rem = mstots(target_delay);
         while (nanosleep(&ts, &ts_rem)) ts = ts_rem;
@@ -1485,7 +1486,7 @@ hb_check_fist_sticky()
     if (target_delay != 0)
     {
         log_message(MTC_LOG_DEBUG,
-                    "HB(FIST): heartbeat delay is %d ms\n", target_delay);
+                    "HB(FIST): heartbeat delay is %"PRId64" ms\n", target_delay);
 
         ts = mstots(target_delay);
         while (nanosleep(&ts, &ts_rem)) ts = ts_rem;

--- a/daemon/sc_func.c
+++ b/daemon/sc_func.c
@@ -39,6 +39,7 @@
 #include <unistd.h>
 #include <time.h>
 #include <assert.h>
+#include <inttypes.h>
 
 #include "mtctypes.h"
 #include "mtcerrno.h"
@@ -551,7 +552,7 @@ script_service_do_query_liveset(
             if (!xapi_approaching_timeout_reported ||
                 (logmask & MTC_LOG_MASK_SC_WARNING))
             {
-                log_message(MTC_LOG_WARNING, "SC: (%s) reporting \"Xapi approaching timeout\". now=%d start=%d.\n", __func__, now, xapimon->time_healthcheck_start);
+                log_message(MTC_LOG_WARNING, "SC: (%s) reporting \"Xapi approaching timeout\". now=%"PRId64" start=%"PRId64".\n", __func__, now, xapimon->time_healthcheck_start);
             }
             l->xapi_approaching_timeout = TRUE;
         }

--- a/daemon/sm.c
+++ b/daemon/sm.c
@@ -42,6 +42,7 @@
 #include <signal.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 
 
@@ -322,7 +323,8 @@ MTC_STATIC void
 print_liveset(
     MTC_S32     pri,
     PMTC_S8     log_string,
-    MTC_HOSTMAP hostmap);
+    MTC_HOSTMAP hostmap)
+__attribute__((format(printf, 2, 0)));
 
 MTC_STATIC void
 wait_until_HBSF_state_stable();
@@ -2289,7 +2291,7 @@ wait_until_HBSF_state_stable()
                 {
                     log_maskable_debug_message(FH_TRACE,
                         "FH: waiting for HB from host (%d),"
-                        " time since last HB receive = %d.\n",
+                        " time since last HB receive = %"PRId64".\n",
                         index, now - phb->time_last_HB[index]);
                     logged_hb[index] = TRUE;
                 }
@@ -2304,7 +2306,7 @@ wait_until_HBSF_state_stable()
                 {
                     log_maskable_debug_message(FH_TRACE,
                         "FH: waiting for SF from host (%d),"
-                        " time since last SF update = %d.\n",
+                        " time since last SF update = %"PRId64".\n",
                         index,
                         now - psf->time_last_SF[index]);
                     logged_sf[index] = TRUE;
@@ -2543,7 +2545,7 @@ wait_until_all_hosts_have_consistent_view(
             MTC_HOSTMAP_SET(removedhost, selected);
         }
 
-        log_message(MTC_LOG_WARNING, "after merger:\n", index);
+        log_message(MTC_LOG_WARNING, "after merger: %d\n", index);
         for (index = 0; _is_configured_host(index); index++)
         {
             MTC_HOSTMAP_INTERSECTION(phb->raw[index].hbdomain, '=',

--- a/daemon/watchdog.c
+++ b/daemon/watchdog.c
@@ -752,7 +752,7 @@ watchdog_create(
     new = malloc(sizeof(WATCHDOG_INSTANCE));
     if (new == NULL) 
     {
-        log_internal(MTC_LOG_ERR, "WD: cannnot malloc size = %d.\n", sizeof(WATCHDOG_INSTANCE));
+        log_internal(MTC_LOG_ERR, "WD: cannnot malloc size = %zu.\n", sizeof(WATCHDOG_INSTANCE));
         ret = MTC_ERROR_WD_INSUFFICIENT_RESOURCE;
         goto error_return;
     }

--- a/daemon/xapi_mon.c
+++ b/daemon/xapi_mon.c
@@ -47,6 +47,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <inttypes.h>
 
 
 //
@@ -438,7 +439,7 @@ xapimon(
         if (target_delay != 0)
         {
             log_message(MTC_LOG_DEBUG,
-                        "XM(FIST): xapi healthcheck delay is %d ms\n", target_delay);
+                        "XM(FIST): xapi healthcheck delay is %"PRId64" ms\n", target_delay);
             xm_sleep(target_delay - (_getms() - start));
         }
 

--- a/include/log.h
+++ b/include/log.h
@@ -195,7 +195,8 @@ extern void
 log_message(
     MTC_S32 priority,
     PMTC_S8 fmt,
-    ...);
+    ...)
+__attribute__((format (printf, 2, 3)));
 
 
 // log_bin

--- a/include/mtctypes.h
+++ b/include/mtctypes.h
@@ -55,6 +55,7 @@
 
 #include <sys/time.h>
 #include <stddef.h>
+#include <stdint.h>
 
 //
 //
@@ -128,11 +129,11 @@ typedef signed short    MTC_S16;    // 16 bits
 // However, int is 4 bytes for both.
 //
 
-typedef unsigned int   MTC_U32;    // 32 bits
-typedef signed int     MTC_S32;    // 32 bits
+typedef uint32_t   MTC_U32;    // 32 bits
+typedef int32_t     MTC_S32;    // 32 bits
 
-typedef unsigned long long MTC_U64; // 64 bits
-typedef long long MTC_S64;          // 64 bits
+typedef uint64_t MTC_U64; // 64 bits
+typedef int64_t MTC_S64;          // 64 bits
 
 
 //

--- a/lib/weightio.c
+++ b/lib/weightio.c
@@ -121,7 +121,7 @@
 MTC_STATUS
 open_hostweight_file(int *fd, int *err_no)
 {
-    if ((*fd = open(HA_HOST_WEIGHT_FILE, O_RDWR|O_CREAT)) < 0)
+    if ((*fd = open(HA_HOST_WEIGHT_FILE, O_RDWR|O_CREAT, 00400)) < 0)
     {
         *err_no = errno;
         return MTC_ERROR_WEIGHT_OPEN;

--- a/lib/weightio.c
+++ b/lib/weightio.c
@@ -121,7 +121,7 @@
 MTC_STATUS
 open_hostweight_file(int *fd, int *err_no)
 {
-    if ((*fd = open(HA_HOST_WEIGHT_FILE, O_RDWR|O_CREAT, 00400)) < 0)
+    if ((*fd = open(HA_HOST_WEIGHT_FILE, O_RDWR|O_CREAT, 0400)) < 0)
     {
         *err_no = errno;
         return MTC_ERROR_WEIGHT_OPEN;


### PR DESCRIPTION
When O_CREAT is used then the file mode must be specified, otherwise it'll be something random from the stack:
```
The mode argument must be supplied if O_CREAT or O_TMPFILE is specified in flags; if it is not supplied, some arbitrary bytes from the stack will be applied as the file mode
```

The file is opened read/write so set matching permission bits.

In `command/stubs.c` (used by `writestatefile`) we need to call `vfprintf` with `ap`, instead of `fprintf`.
`fprintf` would expect the actual arguments, whereas `vfprintf` will forward the varargs correctly.