### PR TITLE
CA-407106: fix various XHA warnings from the Clang static analyzer

### DIFF
--- a/.codechecker.json
+++ b/.codechecker.json
@@ -1,0 +1,7 @@
+{
+  "analyze": [
+    "--disable=clang-diagnostic-reserved-macro-identifier",
+    "--disable=clang-diagnostic-reserved-identifier",
+    "--disable=clang-diagnostic-unused-parameter"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ scripts/generr.o
 scripts/ha_errnorc
 compile_commands.json
 .cache/
+*.o

--- a/commands/cleanupwatchdog.c
+++ b/commands/cleanupwatchdog.c
@@ -391,13 +391,16 @@ main(
         id[idnum++] = strtol(buf, &endptr, 10);
         if (*endptr != '\0') 
         {
+           (void)fclose(fp);
             return MTC_EXIT_INVALID_PARAMETER;
         }
         if (idnum >= MAX_WATCHDOG_INSTANCE) 
         {
+           (void)fclose(fp);
             return MTC_EXIT_INVALID_PARAMETER;
         }
     }
+    (void)fclose(fp);
     for (idindex = 0; idindex < idnum; idindex++)
     {
         if (id[idindex] == 0) 

--- a/commands/writestatefile.c
+++ b/commands/writestatefile.c
@@ -156,8 +156,6 @@ main(
         exit(status_to_exit(MTC_ERROR_SF_OPEN));
     }
 
-    status = MTC_ERROR_INVALID_PARAMETER;
-
     if (strcmp(argv[1], "setinit") == 0)
     {
         status = global_init_state(sf);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -219,7 +219,9 @@ main(
     //  logrotate may send SIGHUP regardless of the state of xha. 
     //
 
-    sigignore(SIGHUP);
+    struct sigaction ignore = { 0 };
+    ignore.sa_handler = SIG_IGN;
+    sigaction(SIGHUP, &ignore, NULL);
         
     //  Initialize ha_config in BSS.
     //  (static initialization causes a warning for unknown reason)
@@ -315,7 +317,7 @@ main(
 
     for (sig = 1; sig < _NSIG; sig++)
     {
-        sigignore(sig);
+        sigaction(sig, &ignore, NULL);
     }
 
     //  #### Set resource limit of core size to max value
@@ -366,7 +368,6 @@ main(
 
     //  #### Initialize internal modules (phase 0 and 1)
 
-    init_index = 0;
     for (phase = 0; phase < 2; phase++)
     {
         for (init_index = 0; init_index < N_INIT_FUNCS; init_index++)
@@ -420,18 +421,19 @@ main(
 //
 //  sigcatch -
 //
-//  signal handler for sigset().
+//  signal handler for sigaction().
 //
 //  sigcatch may be invoked in any thread context in any time.
 //  Acquiring any lock which does not support recursive in this function causes deadlock.
+//
+//  action.sa_flags is 0, which means that the signal that triggerred the handler
+//  is automatically blocked already
 //
 
 MTC_STATIC void
 sigcatch(
     int signo)
 {
-    sigset(signo, sigcatch);
-
     switch (signo)
     {
     case SIGTERM:
@@ -491,10 +493,21 @@ post_phase_init(
         }
 
         //  Now it's time to catch signals.
+        static const int signals[] = { SIGTERM, SIGCHLD, SIGHUP };
+        sigset_t mask;
+        unsigned i;
+        struct sigaction action = { 0 };
+        action.sa_handler = sigcatch;
+        sigemptyset(&mask);
 
-        sigset(SIGTERM, sigcatch);
-        sigset(SIGCHLD, sigcatch);
-        sigset(SIGHUP, sigcatch);
+        for (i = 0; i < sizeof(signals) / sizeof(signals[0]); i++) {
+            int sig = signals[i];
+            sigaddset(&mask, sig);
+
+            sigaction(sig, &action, NULL);
+        }
+
+        sigprocmask(SIG_UNBLOCK, &mask, NULL);
     }
 }
 

--- a/daemon/sc_sv.c
+++ b/daemon/sc_sv.c
@@ -322,7 +322,6 @@ script_service_thread(
         memset((void *)&response, 0, sizeof(response));
 
         FD_ZERO(&fds);
-        nfds = 0;
 
         FD_SET(listening_socket, &fds);
         nfds = listening_socket;

--- a/daemon/sm.c
+++ b/daemon/sm.c
@@ -2353,13 +2353,10 @@ wait_until_all_hosts_have_consistent_view(
                     remote_hbdomain_onsf, remote_sfdomain_onhb,
                     removedhost, tmp_hostmap;
 
-#if 1   // TBD - do we need this timeout?
+    // TBD - do we need this timeout?
     MTC_CLOCK       start = _getms();
 
-    while (!consistent && _getms() - start < timeout)
-#else
-    while (!consistent)
-#endif
+    do
     {
         consistent = TRUE;
 
@@ -2417,10 +2414,14 @@ wait_until_all_hosts_have_consistent_view(
 
         if (!consistent)
         {
+            if (_getms() - start >= timeout) {
+                index = -1;
+                break;
+            }
             mssleep(100);
             sm_wait_signals_sm_hb_sf(TRUE, TRUE, TRUE, -1);
         }
-    }
+    } while(!consistent);
 
     com_reader_lock(sm_object, (void **) &psm);
     com_reader_lock(hb_object, (void **) &phb);

--- a/daemon/sm.c
+++ b/daemon/sm.c
@@ -811,16 +811,13 @@ sm(
 }
 
 
-MTC_STATIC void
-rendezvous(
-    SM_PHASE    phase1,
-    SM_PHASE    phase2,
-    SM_PHASE    phase3,
-    MTC_BOOLEAN on_heartbeat,
-    MTC_BOOLEAN on_statefile)
-{
 #if RENDEZVOUS_FAULT_HANDLING
-    void rendezvous_wait(SM_PHASE p1, SM_PHASE p2)
+MTC_STATIC void
+rendezvous_wait(
+     SM_PHASE p1,
+     SM_PHASE p2,
+     MTC_BOOLEAN on_heartbeat,
+     MTC_BOOLEAN on_statefile)
     {
         PCOM_DATA_SM    psm;
         PCOM_DATA_HB    phb;
@@ -901,12 +898,22 @@ rendezvous(
             hb_SF_cancel_accelerate();
         }
     }
+#endif
 
+MTC_STATIC void
+rendezvous(
+    SM_PHASE    phase1,
+    SM_PHASE    phase2,
+    SM_PHASE    phase3,
+    MTC_BOOLEAN on_heartbeat,
+    MTC_BOOLEAN on_statefile)
+{
+#if RENDEZVOUS_FAULT_HANDLING
     set_sm_phase(phase1);
-    rendezvous_wait(phase1, phase2);
+    rendezvous_wait(phase1, phase2, on_heartbeat, on_statefile);
 
     set_sm_phase(phase2);
-    rendezvous_wait(phase2, phase3);
+    rendezvous_wait(phase2, phase3, on_heartbeat, on_statefile);
 #else
     set_sm_phase(phase2);
 #endif
@@ -1867,15 +1874,11 @@ check_pool_state()
 
 
 MTC_STATIC MTC_BOOLEAN
-update_sfdomain()
-{
-    MTC_CLOCK       now;
-    MTC_S8          hostmap[MAX_HOST_NUM + 1] = {0};
-    MTC_BOOLEAN     changed = FALSE;
-
-    MTC_BOOLEAN update_sfdomain_sub(
+update_sfdomain_sub(
+        MTC_CLOCK now,
+        MTC_S8 hostmap[MAX_HOST_NUM + 1],
         MTC_BOOLEAN writable)
-    {
+{
         PCOM_DATA_SF    psf;
         MTC_BOOLEAN changed = FALSE;
         MTC_S32     index;
@@ -1964,14 +1967,21 @@ update_sfdomain()
         }
 
         return changed;
-    }
+}
+
+MTC_STATIC MTC_BOOLEAN
+update_sfdomain()
+{
+    MTC_CLOCK       now;
+    MTC_S8          hostmap[MAX_HOST_NUM + 1] = {0};
+    MTC_BOOLEAN     changed = FALSE;
 
     now = _getms();
 
-    changed = update_sfdomain_sub(FALSE);
+    changed = update_sfdomain_sub(now, hostmap, FALSE);
     if (changed)
     {
-        changed = update_sfdomain_sub(TRUE);
+        changed = update_sfdomain_sub(now, hostmap, TRUE);
         if (changed)
         {
             log_message(MTC_LOG_DEBUG,
@@ -2782,18 +2792,12 @@ sm_send_signals_sm_hb_sf(
 }
 
 
-MTC_STATIC MTC_BOOLEAN
-sm_wait_signals_sm_hb_sf(
+static MTC_BOOLEAN
+check_sigs(
     MTC_BOOLEAN sm_sig,
     MTC_BOOLEAN hb_sig,
-    MTC_BOOLEAN sf_sig,
-    MTC_CLOCK   timeout)
+    MTC_BOOLEAN sf_sig)
 {
-    MTC_BOOLEAN signaled;
-    MTC_CLOCK   start = _getms();
-
-    MTC_BOOLEAN check_sigs()
-    {
         MTC_BOOLEAN signaled = FALSE;
 
         if (sm_sig && smvar.sm_sig)
@@ -2813,7 +2817,17 @@ sm_wait_signals_sm_hb_sf(
         }
 
         return signaled;
-    }
+}
+
+MTC_STATIC MTC_BOOLEAN
+sm_wait_signals_sm_hb_sf(
+    MTC_BOOLEAN sm_sig,
+    MTC_BOOLEAN hb_sig,
+    MTC_BOOLEAN sf_sig,
+    MTC_CLOCK   timeout)
+{
+    MTC_BOOLEAN signaled;
+    MTC_CLOCK   start = _getms();
 
     if (timeout == 0)
     {
@@ -2821,7 +2835,7 @@ sm_wait_signals_sm_hb_sf(
     }
 
     pthread_mutex_lock(&smvar.mutex);
-    while (!(signaled = check_sigs()) &&
+    while (!(signaled = check_sigs(sm_sig, hb_sig, sf_sig)) &&
            ((timeout < 0)? TRUE: (_getms() - start < timeout)))
     {
         if (timeout < 0)

--- a/daemon/xapi_mon.c
+++ b/daemon/xapi_mon.c
@@ -775,7 +775,6 @@ wait_pid_timeout(
     while ((ret_pid = waitpid(pid, pstat, WNOHANG)) == 0 &&
            now < start_time + timeout)
     {
-        ret_pid = 0;
         nanosleep(&sleep_ts, &sleep_rem);
         now = _getms();
     }

--- a/include/sm.h
+++ b/include/sm.h
@@ -365,7 +365,7 @@ sm_initialize(
     MTC_S32 phase);
 
 extern void
-self_fence();
+self_fence(MTC_STATUS code, PMTC_S8 message);
 
 extern MTC_BOOLEAN
 sm_get_join_block();


### PR DESCRIPTION
Fixes for:
* CA-407106: Fix various build and static analyzer warnings
* CA-407106: Fix potential uninitialized value during timeout
* CA-407106: Close file descriptor
* CA-407106: Use backtrace and backtrace_symbols
*  CA-407106: Fix 'variable set but not used' warnings
* CA-407106: Avoid using deprecated sigset and sigignore functions
* CA-407106: Fix build with clang: remove nested functions
* CA-407106: Fix missing arguments to self_fence
* Update .gitignore with CodeChecker and binary files
* CA-406953: fix more undefined behaviour
* CA-406953: Fix format string warnings
* CA-406953: Use fixed size integer types
* Tell the compiler that `log_message` takes a format string as argument
* Update .gitignore with CodeChecker files