### PR TITLE
CA-407313: Replace semaphore & spinlock with rwlock

### DIFF
--- a/daemon/log.c
+++ b/daemon/log.c
@@ -71,6 +71,12 @@ static FILE                 *fpLogfile = NULL;
 static MTC_BOOLEAN          initialized = FALSE;
 
 
+/*
+ * lock exists to protect fpLogfile
+ * Readers should hold the lock when access fpLogfile and the FILE it points to
+ * Writers should hold the lock when assigning fpLogfile or when freeing the
+ *  object it points to
+ */
 static pthread_rwlock_t     lock;
 
 
@@ -522,7 +528,7 @@ log_fsync()
         return;
     }
 
-    pthread_rwlock_wrlock(&lock);
+    pthread_rwlock_rdlock(&lock);
     if (fpLogfile)
     {
         fsync(fileno(fpLogfile));

--- a/daemon/log.c
+++ b/daemon/log.c
@@ -225,40 +225,43 @@ void log_message(MTC_S32 priority, PMTC_S8 fmt, ...)
         return;
     }
 
-    if (priority & MTC_LOG_PRIVATELOG && fpLogfile != NULL && privatelogflag)
+    if (priority & MTC_LOG_PRIVATELOG && privatelogflag)
     {
         pthread_rwlock_rdlock(&lock);
 
-        MTC_S32 i = 0;
-
-        while (prioritynames[i].c_val != -1 &&
-               prioritynames[i].c_val != LOG_PRI(priority))
+        if (fpLogfile != NULL)
         {
-            i++;
-        }
+            MTC_S32 i = 0;
+
+            while (prioritynames[i].c_val != -1 &&
+                   prioritynames[i].c_val != LOG_PRI(priority))
+            {
+                i++;
+            }
       
-        now = time(NULL);
-        ptm = localtime(&now);
-        flockfile(fpLogfile);
-        fprintf(fpLogfile, "%s %02d %02d:%02d:%02d %s %04d [%s] ",
-                monthnames[ptm->tm_mon], ptm->tm_mday,
-                ptm->tm_hour, ptm->tm_min, ptm->tm_sec,
-                ptm->tm_zone, 1900 + ptm->tm_year, prioritynames[i].c_name);
+            now = time(NULL);
+            ptm = localtime(&now);
+            flockfile(fpLogfile);
+            fprintf(fpLogfile, "%s %02d %02d:%02d:%02d %s %04d [%s] ",
+                    monthnames[ptm->tm_mon], ptm->tm_mday,
+                    ptm->tm_hour, ptm->tm_min, ptm->tm_sec,
+                    ptm->tm_zone, 1900 + ptm->tm_year, prioritynames[i].c_name);
     
-        va_start(ap, fmt);
-        vfprintf(fpLogfile, fmt, ap);
-        funlockfile(fpLogfile);
-        va_end(ap);
+            va_start(ap, fmt);
+            vfprintf(fpLogfile, fmt, ap);
+            funlockfile(fpLogfile);
+            va_end(ap);
 
-        fflush(fpLogfile);
+            fflush(fpLogfile);
 
-        //
-        // Sometime, fsync() takes seconds or more.
-        // It may cause unexpected watchdog timeout.
-        // So we deceided that we do not use fsync().
-        //
-        // fsync(fileno(fpLogfile));
-        //
+            //
+            // Sometime, fsync() takes seconds or more.
+            // It may cause unexpected watchdog timeout.
+            // So we deceided that we do not use fsync().
+            //
+            // fsync(fileno(fpLogfile));
+            //
+        }
 
         pthread_rwlock_unlock(&lock);
     }

--- a/daemon/log.c
+++ b/daemon/log.c
@@ -127,7 +127,7 @@ MTC_S32 log_initialize()
 //  This function should be called from ha_log_reopen script
 //  when log files is rotated.
 //
-//  Smaple logrotate config file </etc/logrotate.d/xha>
+//  Sample logrotate config file </etc/logrotate.d/xha>
 //    /var/log/xha.log {
 //          rotate 5
 //          size 100k
@@ -140,8 +140,6 @@ MTC_S32 log_initialize()
 //  paramaters
 //
 //  return value
-//    0: success
-//    not 0: fail
 //
 
 void log_reopen()

--- a/daemon/log.c
+++ b/daemon/log.c
@@ -219,10 +219,10 @@ void log_message(MTC_S32 priority, PMTC_S8 fmt, ...)
         return;
     }
 
-    pthread_rwlock_rdlock(&lock);
-
     if (priority & MTC_LOG_PRIVATELOG && fpLogfile != NULL && privatelogflag)
     {
+        pthread_rwlock_rdlock(&lock);
+
         MTC_S32 i = 0;
 
         while (prioritynames[i].c_val != -1 &&
@@ -254,7 +254,7 @@ void log_message(MTC_S32 priority, PMTC_S8 fmt, ...)
         // fsync(fileno(fpLogfile));
         //
 
-
+        pthread_rwlock_unlock(&lock);
     }
     if ((logmask & MTC_LOG_MASK_SYSLOG) || (priority & MTC_LOG_SYSLOG))
     {
@@ -262,8 +262,6 @@ void log_message(MTC_S32 priority, PMTC_S8 fmt, ...)
         vsyslog(LOG_PRI(priority), fmt, ap);
         va_end(ap);
     }
-
-    pthread_rwlock_unlock(&lock);
 }
 
 
@@ -292,10 +290,9 @@ void log_bin(MTC_S32 priority, PMTC_S8 data, MTC_S32 size)
         return;
     }
 
-    pthread_rwlock_rdlock(&lock);
-
     if (priority & MTC_LOG_PRIVATELOG && fpLogfile != NULL && privatelogflag)
     {
+        pthread_rwlock_rdlock(&lock);
         flockfile(fpLogfile);
         for (line = 0, pos = 0; pos < size; line++)
         {
@@ -323,9 +320,8 @@ void log_bin(MTC_S32 priority, PMTC_S8 data, MTC_S32 size)
         //
         // fsync(fileno(fpLogfile));
         // 
+        pthread_rwlock_unlock(&lock);
     }
-
-    pthread_rwlock_unlock(&lock);
 }
 
 //


### PR DESCRIPTION
rwlock decreases the amount of blocking for logging by separating the 
locking for logging to thread safe stdio versus thread unsafe 
operations such as reopening files.

Use flockfile/funlockfile to ensure contiguous log messages where 
needed.

Signed-off-by: Gerald Elder-Vass <gerald.elder-vass@cloud.com>

Tested on a pool which previously had HA enabled; disabled HA, updated xha, re-enabled HA and monitored the pool for a while (and some operations to spark some logging)