### PR TITLE
CP-53906: Print host index in query_liveset

### DIFF
--- a/commands/calldaemon.c
+++ b/commands/calldaemon.c
@@ -566,6 +566,7 @@ print_query_liveset(
            l->host[l->localhost_index].host_id + 12,
            l->host[l->localhost_index].host_id + 16,
            l->host[l->localhost_index].host_id + 20);
+    printf("    <HostIndex>%d</HostIndex>\n", l->localhost_index);
     printf("  </localhost>\n");
     if (l->status == LIVESET_STATUS_ONLINE) 
     {
@@ -578,6 +579,7 @@ print_query_liveset(
                    l->host[h_index].host_id + 12,
                    l->host[h_index].host_id + 16,
                    l->host[h_index].host_id + 20);
+            printf("    <HostIndex>%d</HostIndex>\n", h_index);
             printf("    <liveness>%s</liveness>\n", 
                    (l->host[h_index].liveness)?"TRUE":"FALSE");
             printf("    <master>%s</master>\n", 
@@ -610,6 +612,7 @@ print_query_liveset(
                    l->host[h_index].host_id + 12,
                    l->host[h_index].host_id + 16,
                    l->host[h_index].host_id + 20);
+            printf("      <HostIndex>%d</HostIndex>\n", h_index);
             printf("      <time_since_last_update_on_statefile>%d</time_since_last_update_on_statefile>\n", 
                    l->host[h_index].time_since_last_update_on_sf);
             printf("      <time_since_last_heartbeat>%d</time_since_last_heartbeat>\n",

--- a/daemon/heartbeat.c
+++ b/daemon/heartbeat.c
@@ -1302,7 +1302,7 @@ receive_hb()
     }
 
 
-    // sf accelarete
+    // sf accelerate
     if (pkt.SF_accelerate)
     {
         sf_accelerate();


### PR DESCRIPTION
Host index (a number range from 0 ~ number_of_hosts - 1) is an important information of xHA. But it's not easy for us to find each host's index. The only method currently is to check each host's xha.log to get it.

Solution:
Print host index in the result of the command `/opt/xensource/debug/debug_ha_query_liveset`. The command also returns each host's UUID. Then we can associate the host index with host via UUID.
We can also get it from `debug_ha_query_liveset.out` in the status-report.