### PR TITLE
CA-411986: Fix heartbeat latency calculation

### DIFF
--- a/daemon/heartbeat.c
+++ b/daemon/heartbeat.c
@@ -881,7 +881,12 @@ hb_send(
 
             com_writer_lock(hb_object, (void **) &phb);
             phb->time_last_HB[_my_index] = now;
-            phb->latency = now - last;
+
+            // Calculate heartbeat latency:
+            // 1. If sending the heartbeat exceeds the configured interval, set
+            //    latency to the actual elapsed time.
+            // 2. Otherwise, set latency to the configured heartbeat interval.
+            phb->latency = _max(now - last - _t1 * ONE_SEC, _t1 * ONE_SEC);
             phb->latency_max = (phb->latency_max < 0)? phb->latency:
                                 _max(phb->latency_max, phb->latency);
             phb->latency_min = (phb->latency_min < 0)? phb->latency:


### PR DESCRIPTION
The `heartbeat_latency` is the interval between each heartbeat transmission. After splitting the heartbeat thread into two threads (sending and receiving), the latency is now measured immediately after sending a heartbeat.

With this change, the calculation logic should be updated as follows:
1. If sending the heartbeat takes longer than the configured heartbeat interval, `heartbeat_latency` is the actual elapsed time.
2. Otherwise, `heartbeat_latency` is the configured heartbeat interval.