### PR TITLE
Fix initialisation of unknown index value which overflows `bvar.sa_to`

### DIFF
--- a/daemon/heartbeat.c
+++ b/daemon/heartbeat.c
@@ -1107,10 +1107,11 @@ send_hb()
     if (!hb_check_fist("hb.isolate") &&
         !fist_on("hb.send.lostpacket"))
     {
+        index = 0;
         const socket_address *ss = &hbvar.sa_to[index];
         const socklen_t dest_len = ss->sa.sa_family == AF_INET ? sizeof(ss->sa_in) : sizeof(ss->sa_in6);
 
-        for (index = 0; _is_configured_host(index); index++)
+        for (; _is_configured_host(index); index++)
         {
             if (index != _my_index)
             {


### PR DESCRIPTION
Fix initialisation of unknown index value which overflows `bvar.sa_to`

Signed-off-by: Erwan Croze <erwan.croze@vates.tech>